### PR TITLE
Added configuration files for ReadTheDocs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,14 @@
+matplotlib
+numpy
+scipy
+click
+scikit-learn
+imbalanced-learn
+prince
+openml
+jax==0.4.10
+jaxlib==0.4.10
+PennyLane
+PennyLane-qiskit
+simanneal
+optax


### PR DESCRIPTION
Problem: 
- From September 2023, ReadTheDocs does require configuration files, namely a .readthedocs.yaml. 

Solution: 
- We created a new config based on a working template.